### PR TITLE
fixed memoryleak: close matplotlib after drawing figures

### DIFF
--- a/Florence.py
+++ b/Florence.py
@@ -44,7 +44,9 @@ def fig_to_pil(fig):
     buf = io.BytesIO()
     fig.savefig(buf, format='png', dpi=100, bbox_inches='tight', pad_inches=0)
     buf.seek(0)
-    return Image.open(buf)
+    pil = Image.open(buf)
+    plt.close()
+    return pil
 
 def plot_bbox(image, data):
     fig, ax = plt.subplots()


### PR DESCRIPTION
In batch processing soon this warning will appear in console:
`RuntimeWarning: More than 20 figures have been opened. Figures created through the pyplot interface (matplotlib.pyplot.figure) are retained until explicitly closed and may consume too much memory. (To control this warning, see the rcParam figure.max_open_warning). Consider using matplotlib.pyplot.close()`

Some time after this entire ComfyUI will crash.

This simply calls matplotlib.pyplot.close() as suggested in the message after the plot image has been created from the figure.
I am not knowledgeable enough of matplotlib scope to know if this will have side effects outside the Florence class, but things seem to work from what I was able to test.

As a further thought, I think it might be a good idea to have a "Enable Preview" toggle, or migrate preview into a "F_BBOXES to Preview Image" node of it's own, so these images are not generated unnecessarily when preview is not needed or used.