### PR TITLE
matplotlib 3.9.0 bug workaround

### DIFF
--- a/Florence.py
+++ b/Florence.py
@@ -47,7 +47,15 @@ def fig_to_pil(fig):
     return Image.open(buf)
 
 def plot_bbox(image, data):
-    fig, ax = plt.subplots()
+    if matplotlib.__version__ == "3.9.0": # workaround for random failure bug in matplotlib 3.9.0
+        ax = None
+        while ax is None:
+            try:
+                fig, ax = plt.subplots()
+            except ValueError:
+                continue
+    else:
+        fig, ax = plt.subplots()
     fig.set_size_inches(image.width / 100, image.height / 100)
     ax.imshow(image)
     for i, (bbox, label) in enumerate(zip(data['bboxes'], data['labels'])):


### PR DESCRIPTION
There is a bug in matplotlib 3.9.0 that will cause (rare) random failure when calling matplotlib.pyplot.subplots(), which will result in node crash.
This issue does not appear in 3.8.x and is apparently due to be fixed in 3.9.1, which currently does not have a due date but github says is "94% complete".

https://github.com/matplotlib/matplotlib/pull/28269
https://github.com/matplotlib/matplotlib/issues/28267

I don't know if temporary environmental workarounds like this make sense to merge to main.
This is likely not an issue in manual use but fatal in batch processing.
For my purposes being able to disable previews would solve this, but I expect some people want to see those in batch processing as well.